### PR TITLE
Fix calculation of line height in StaticText.

### DIFF
--- a/src/widget.lua
+++ b/src/widget.lua
@@ -519,10 +519,13 @@ function StaticText:init(text, args)
     Text.init(self, args or {})
 
     self._lines = {}
-    local _, line_count = text:gsub("[^\n]*", function(line)
+    text = text .. "\n"
+
+    for line in text:gmatch("(.-)\n") do
         table.insert(self._lines, line)
-    end)
-    self.height = line_count * self._line_height
+    end
+
+    self.height = #self._lines * self._line_height
 end
 
 function StaticText:render_background(cr)


### PR DESCRIPTION
On my machine, it seemed that using the original `gsub` implementation would seem to find an extra blank line, even for text with no newline characters in it - this then made the line height too big. This approach using `gmatch` seems to be more reliable for me.