### PR TITLE
Implement Widget Rendering Sandboxing

### DIFF
--- a/examples/cpu.lua
+++ b/examples/cpu.lua
@@ -71,6 +71,7 @@ local conkyrc = conky or {}
 conkyrc.config = {
     lua_load = script_dir .. "cpu.lua",
     lua_startup_hook = "conky_setup",
+    lua_draw_hook_pre = "conky_paint_background",
     lua_draw_hook_post = "conky_update",
 
     update_interval = 1,

--- a/examples/graphs.lua
+++ b/examples/graphs.lua
@@ -52,6 +52,7 @@ local conkyrc = conky or {}
 conkyrc.config = {
     lua_load = script_dir .. "graphs.lua",
     lua_startup_hook = "conky_setup",
+    lua_draw_hook_pre = "conky_paint_background",
     lua_draw_hook_post = "conky_update",
 
     update_interval = 1,

--- a/examples/text.lua
+++ b/examples/text.lua
@@ -73,6 +73,7 @@ local conkyrc = conky or {}
 conkyrc.config = {
     lua_load = script_dir .. "text.lua",
     lua_startup_hook = "conky_setup",
+    lua_draw_hook_pre = "conky_paint_background",
     lua_draw_hook_post = "conky_update",
 
     update_interval = 1,


### PR DESCRIPTION
Sorry for the delay, had some life / work stuff going on and there was
a couple of bugs and I wanted to try and find a way to better separate
the drawing of background and foreground but cairo isn't very flexible
in that regard.

This uses cairo_surface_create_for_rectangle to give each widget
it's own cairo_t, this means that Widgets can no longer draw
outside the current boundry that is set for them.

Unfortunately this also means the backgrounds need to also be redrawn 
each cycle to make semi transparent shapes render correctly. With the way
conky work's I don't know how that actually worked before.

cairo_surface_create_for_rectangle was added to conky in v1.19.1
